### PR TITLE
make clearDatabase configurable and do startup of the test db contain…

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/common/testutil/GitsPostgresSqlContainer.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/testutil/GitsPostgresSqlContainer.java
@@ -1,8 +1,35 @@
 package de.unistuttgart.iste.gits.common.testutil;
 
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-public class GitsPostgresSqlContainer extends PostgreSQLContainer<GitsPostgresSqlContainer> {
+/**
+ * This class is a singleton that starts a postgresql container for testing.
+ * It can be used in two ways:
+ * <p>
+ * 1. Use the {@link GitsPostgresSqlContainer} as a JUnit 5 extension:
+ * <pre>
+ *         &#64;ExtendWith(GitsPostgresSqlContainer.class)
+ *         public class MyTest {
+ *         // ...
+ *         }
+ *      </pre>
+ * This is the preferred way and is automatically done by the {@link GraphQlApiTest} annotation.
+ * <p>
+ * 2. Use the {@link GitsPostgresSqlContainer} as a container:
+ * <pre>
+ *         &#64;Testcontainers
+ *         public class MyTest {
+ *
+ *            &#64;Container
+ *            private static final GitsPostgresSqlContainer container = GitsPostgresSqlContainer.getInstance();
+ *            // ...
+ *         }
+ *      </pre>
+ */
+public class GitsPostgresSqlContainer extends PostgreSQLContainer<GitsPostgresSqlContainer>
+        implements BeforeAllCallback {
 
     private static final String IMAGE_VERSION = "postgres:latest";
 
@@ -32,7 +59,8 @@ public class GitsPostgresSqlContainer extends PostgreSQLContainer<GitsPostgresSq
         //do nothing, JVM handles shut down
     }
 
-
-
-
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        getInstance().start();
+    }
 }

--- a/src/main/java/de/unistuttgart/iste/gits/common/testutil/GraphQlApiTest.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/testutil/GraphQlApiTest.java
@@ -2,7 +2,6 @@ package de.unistuttgart.iste.gits.common.testutil;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.*;
@@ -12,11 +11,12 @@ import java.lang.annotation.*;
  * {@link GraphQlTesterParameterResolver} and {@link ClearDatabase}.
  */
 @ExtendWith(GraphQlTesterParameterResolver.class)
+@ExtendWith(GitsPostgresSqlContainer.class)
+@Testcontainers
 @ExtendWith(ClearDatabase.class)
 @SpringBootTest
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Testcontainers
 public @interface GraphQlApiTest {
 }

--- a/src/main/java/de/unistuttgart/iste/gits/common/testutil/TablesToDelete.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/testutil/TablesToDelete.java
@@ -1,0 +1,15 @@
+package de.unistuttgart.iste.gits.common.testutil;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Use this annotation in test together with {@link ClearDatabase} to
+ * set which tables should be deleted.
+ * This is useful if you want to delete tables in a specific order.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TablesToDelete {
+
+    String[] value();
+}


### PR DESCRIPTION
make clearDatabase configurable and do startup of the test db container automatically with the GraphQlApiTest annotation

## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [x] automated integration test
- [ ] automated acceptance test
- [x] manual, exploratory test

works in the tests
    
## Checklist before requesting a review
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code fulfills all acceptance criteria
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
